### PR TITLE
Support initialising with only options hash

### DIFF
--- a/lib/wunderground.rb
+++ b/lib/wunderground.rb
@@ -13,7 +13,13 @@ class Wunderground
 
   attr_accessor :api_key, :timeout, :throws_exceptions, :language
 
-  def initialize(api_key = nil, extra_params = {})
+  def initialize(*args)
+    extra_params = {}
+    if !args.nil?
+      api_key = args.first if args.first.is_a?(String)
+      extra_params = args.last if args.last.is_a?(Hash)
+    end
+    
     @api_key = api_key || ENV['WUNDERGROUND_API_KEY'] || ENV['WUNDERGROUND_APIKEY'] || self.class.api_key
     @timeout = extra_params[:timeout] || 30
     @throws_exceptions = extra_params[:throws_exceptions] || false

--- a/test/test_wunderground.rb
+++ b/test/test_wunderground.rb
@@ -24,19 +24,6 @@ class TestWunderground < Test::Unit::TestCase
       assert_equal(60,@wunderground.timeout)
       assert_equal('FR',@wunderground.language)
     end
-    should "set an API key from the 'WUNDERGROUND_API_KEY' ENV variable" do
-      ENV['WUNDERGROUND_API_KEY'] = @api_key
-      @wunderground = Wunderground.new
-      assert_equal(@api_key, @wunderground.api_key)
-      ENV.delete('WUNDERGROUND_API_KEY')
-    end
-
-    should "set an API key from the 'WUNDERGROUND_APIKEY' ENV variable" do
-      ENV['WUNDERGROUND_APIKEY'] = @api_key
-      @wunderground = Wunderground.new
-      assert_equal(@api_key, @wunderground.api_key)
-      ENV.delete('WUNDERGROUND_APIKEY')
-    end
 
     should "set an API key via setter" do
       @wunderground = Wunderground.new
@@ -49,6 +36,32 @@ class TestWunderground < Test::Unit::TestCase
       timeout = 30
       @wunderground.timeout = timeout
       assert_equal(timeout, @wunderground.timeout)
+    end
+    
+    context "ENV api key" do
+      setup do
+        ENV['WUNDERGROUND_API_KEY'] = @api_key
+      end
+      
+      teardown do
+        ENV.delete('WUNDERGROUND_API_KEY')
+      end
+      
+      should "set an API key from the 'WUNDERGROUND_API_KEY' ENV variable" do
+        @wunderground = Wunderground.new
+        assert_equal(@api_key, @wunderground.api_key)
+      end
+
+      should "set an API key from the 'WUNDERGROUND_APIKEY' ENV variable" do
+        @wunderground = Wunderground.new
+        assert_equal(@api_key, @wunderground.api_key)
+      end
+      
+      should "set timeout and language in constructor" do
+        @wunderground = Wunderground.new(timeout: 60, language: 'FR')
+        assert_equal(60,@wunderground.timeout)
+        assert_equal('FR',@wunderground.language)
+      end
     end
   end
 


### PR DESCRIPTION
Hello,

I patched wunderground to support this call when your API key is stored in ENV:

```
w_api = Wunderground.new(timeout: 20)
```

I think it is more clear than:

```
w_api = Wunderground.new(nil, timeout: 20)
```

Thanks for the gem, btw.

D.
