### PR TITLE
Fixed Warning When Using with RSpec

### DIFF
--- a/lib/wunderground.rb
+++ b/lib/wunderground.rb
@@ -43,7 +43,7 @@ class Wunderground
   end
 
   def respond_to?(method, include_all = false)
-    method_missing_match?(method) || super(method, include_all)
+    method_missing_match?(method) || super
   end
 
   protected


### PR DESCRIPTION
```
/.gems/ruby/2.0.0/gems/wunderground-1.1.0/lib/wunderground.rb:45: warning: respond_to? is defined here
/.gems/ruby/2.0.0/gems/rspec-mocks-2.14.4/lib/rspec/mocks/extensions/marshal.rb:7: warning: Wunderground#respond_to?(:_dump) is old fashion which takes only one parameter
```
